### PR TITLE
feat: server capacity display, per-node capacity indicators, UI panels

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,3 +22,13 @@ var nodeIndexView = new NodeIndexView()
 nodeIndexView.collection = new Collection(db, NodeModel)
 nodeIndexView.show()
 
+// Watch serverCapacity config and display it
+var serverCapacityValueEl = document.getElementById('server-capacity-value')
+if (serverCapacityValueEl) {
+  var serverCapacityRef = firebaseDb.ref(rawDb, dbPath + '/configuration/serverCapacity')
+  firebaseDb.onValue(serverCapacityRef, function (snapshot) {
+    var capacity = snapshot.val()
+    serverCapacityValueEl.textContent = capacity || '∞'
+  })
+}
+

--- a/index.js
+++ b/index.js
@@ -26,23 +26,27 @@ nodeIndexView.show()
 
 // Watch K from Firebase config
 var configKEl = document.getElementById('config-k')
-if (configKEl) {
-  var kRef = firebaseDb.ref(rawDb, dbPath + '/configuration/K')
-  firebaseDb.onValue(kRef, function (snapshot) {
-    var k = snapshot.val()
-    configKEl.textContent = k != null ? k : '–'
-  })
-}
+var kRef = firebaseDb.ref(rawDb, dbPath + '/configuration/K')
+firebaseDb.onValue(kRef, function (snapshot) {
+  var k = snapshot.val()
+  if (configKEl) configKEl.textContent = k != null ? k : '–'
+  nodeIndexView.globalK = k
+})
 
 // Watch serverCapacity from Firebase config
 var configCapacityEl = document.getElementById('config-server-capacity')
-if (configCapacityEl) {
-  var capacityRef = firebaseDb.ref(rawDb, dbPath + '/configuration/serverCapacity')
-  firebaseDb.onValue(capacityRef, function (snapshot) {
-    var capacity = snapshot.val()
-    configCapacityEl.textContent = capacity || '∞'
-  })
-}
+var capacityRef = firebaseDb.ref(rawDb, dbPath + '/configuration/serverCapacity')
+firebaseDb.onValue(capacityRef, function (snapshot) {
+  var capacity = snapshot.val()
+  if (configCapacityEl) configCapacityEl.textContent = capacity || '∞'
+  nodeIndexView.serverCapacity = capacity
+})
+
+// Watch serverAtCapacity from Firebase config
+var atCapacityRef = firebaseDb.ref(rawDb, dbPath + '/configuration/serverAtCapacity')
+firebaseDb.onValue(atCapacityRef, function (snapshot) {
+  nodeIndexView.serverAtCapacity = !!snapshot.val()
+})
 
 // ── Read-only stats from reports ──
 

--- a/index.js
+++ b/index.js
@@ -22,13 +22,61 @@ var nodeIndexView = new NodeIndexView()
 nodeIndexView.collection = new Collection(db, NodeModel)
 nodeIndexView.show()
 
-// Watch serverCapacity config and display it
-var serverCapacityValueEl = document.getElementById('server-capacity-value')
-if (serverCapacityValueEl) {
-  var serverCapacityRef = firebaseDb.ref(rawDb, dbPath + '/configuration/serverCapacity')
-  firebaseDb.onValue(serverCapacityRef, function (snapshot) {
-    var capacity = snapshot.val()
-    serverCapacityValueEl.textContent = capacity || '∞'
+// ── Read-only config display ──
+
+// Watch K from Firebase config
+var configKEl = document.getElementById('config-k')
+if (configKEl) {
+  var kRef = firebaseDb.ref(rawDb, dbPath + '/configuration/K')
+  firebaseDb.onValue(kRef, function (snapshot) {
+    var k = snapshot.val()
+    configKEl.textContent = k != null ? k : '–'
   })
 }
 
+// Watch serverCapacity from Firebase config
+var configCapacityEl = document.getElementById('config-server-capacity')
+if (configCapacityEl) {
+  var capacityRef = firebaseDb.ref(rawDb, dbPath + '/configuration/serverCapacity')
+  firebaseDb.onValue(capacityRef, function (snapshot) {
+    var capacity = snapshot.val()
+    configCapacityEl.textContent = capacity || '∞'
+  })
+}
+
+// ── Read-only stats from reports ──
+
+var statNodesEl = document.getElementById('stat-nodes')
+var statP2pEl = document.getElementById('stat-p2p')
+var statServerEl = document.getElementById('stat-server')
+
+if (statNodesEl) {
+  var reportsRef = firebaseDb.ref(rawDb, dbPath + '/reports')
+  firebaseDb.onValue(reportsRef, function (snapshot) {
+    var reports = snapshot.val()
+    if (!reports) {
+      statNodesEl.textContent = '0'
+      statP2pEl.textContent = '0'
+      statServerEl.textContent = '0'
+      return
+    }
+
+    var now = Date.now()
+    var total = 0
+    var p2p = 0
+    var server = 0
+
+    for (var id in reports) {
+      var report = reports[id]
+      // Only count recently-active nodes (within 8s, matching collection.js)
+      if (!report.timestamp || now - report.timestamp > 8000) continue
+      total++
+      if (report.transport === 'server') server++
+      else if (report.transport === 'p2p') p2p++
+    }
+
+    statNodesEl.textContent = total
+    statP2pEl.textContent = p2p
+    statServerEl.textContent = server
+  })
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "cannon": "^0.6.2",
         "ecstatic": "^4.1.4",
         "esbuild": "^0.19.0",
+        "events": "^3.3.0",
         "firebase": "^10.7.0",
         "hyperglue2": "1.6.2",
         "inherits": "2.0.4",
@@ -1211,6 +1212,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
       }
     },
     "node_modules/faye-websocket": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "cannon": "^0.6.2",
     "ecstatic": "^4.1.4",
     "esbuild": "^0.19.0",
+    "events": "^3.3.0",
     "firebase": "^10.7.0",
     "hyperglue2": "1.6.2",
     "inherits": "2.0.4",

--- a/share/index.html
+++ b/share/index.html
@@ -11,12 +11,70 @@
       <div id="dom"></div>
       <canvas id="webgl"></canvas>
     </div>
-    <div id="stats-overlay">
+
+    <!-- Config (read-only) -->
+    <div class="ui-overlay ui-panel ui-config">
+      <div class="ui-panel-title">Config</div>
       <div class="stat-row">
-        <span>Server Capacity:</span>
-        <span id="server-capacity-value">∞</span>
+        <span>K</span>
+        <span class="stat-value" id="config-k">–</span>
+      </div>
+      <div class="stat-row">
+        <span>Server Cap</span>
+        <span class="stat-value" id="config-server-capacity">∞</span>
       </div>
     </div>
+
+    <!-- Stats (read-only) -->
+    <div class="ui-overlay ui-panel ui-stats">
+      <div class="ui-panel-title">Network</div>
+      <div class="stat-row">
+        <span>Nodes</span>
+        <span class="stat-value" id="stat-nodes">0</span>
+      </div>
+      <div class="stat-row">
+        <span>P2P</span>
+        <span class="stat-value" id="stat-p2p">0</span>
+      </div>
+      <div class="stat-row">
+        <span>Server</span>
+        <span class="stat-value" id="stat-server">0</span>
+      </div>
+    </div>
+
+    <!-- Legend (read-only) -->
+    <div class="ui-overlay ui-panel ui-legend">
+      <div class="ui-panel-title">Legend</div>
+      <div class="legend-item">
+        <div class="legend-dot" style="background:#44CC44"></div>
+        Healthy
+      </div>
+      <div class="legend-item">
+        <div class="legend-dot" style="background:#FF8C19"></div>
+        Moderate
+      </div>
+      <div class="legend-item">
+        <div class="legend-dot" style="background:#FFCC00"></div>
+        Degraded
+      </div>
+      <div class="legend-item">
+        <div class="legend-dot" style="background:#FF4444"></div>
+        Struggling
+      </div>
+      <div class="legend-item">
+        <div class="legend-dot" style="background:#666666"></div>
+        Disconnected
+      </div>
+      <div class="legend-item">
+        <div class="legend-line" style="background:#686868"></div>
+        P2P link
+      </div>
+      <div class="legend-item">
+        <div class="legend-line" style="background:#44DD44"></div>
+        Server link
+      </div>
+    </div>
+
   </body>
   <script type="text/javascript" src="/build.js"></script>
 </html>

--- a/share/index.html
+++ b/share/index.html
@@ -11,6 +11,9 @@
       <div id="dom"></div>
       <canvas id="webgl"></canvas>
     </div>
+    <div id="stats-overlay" style="position: absolute; top: 10px; right: 10px; background: rgba(0,0,0,0.7); color: white; padding: 10px; border-radius: 4px; font-family: monospace; font-size: 12px;">
+      <div>Server Capacity: <span id="server-capacity-value">∞</span></div>
+    </div>
   </body>
   <script type="text/javascript" src="/build.js"></script>
 </html>

--- a/share/index.html
+++ b/share/index.html
@@ -11,8 +11,11 @@
       <div id="dom"></div>
       <canvas id="webgl"></canvas>
     </div>
-    <div id="stats-overlay" style="position: absolute; top: 10px; right: 10px; background: rgba(0,0,0,0.7); color: white; padding: 10px; border-radius: 4px; font-family: monospace; font-size: 12px;">
-      <div>Server Capacity: <span id="server-capacity-value">∞</span></div>
+    <div id="stats-overlay">
+      <div class="stat-row">
+        <span>Server Capacity:</span>
+        <span id="server-capacity-value">∞</span>
+      </div>
     </div>
   </body>
   <script type="text/javascript" src="/build.js"></script>

--- a/share/index.html
+++ b/share/index.html
@@ -10,6 +10,62 @@
     <div id="node-index">
       <div id="dom"></div>
       <canvas id="webgl"></canvas>
+
+      <!-- Header -->
+      <div class="ui-overlay ui-header">
+        <div class="title">fireflower <span>visualizer</span></div>
+        <div class="node-count" id="ui-node-count"></div>
+      </div>
+
+      <!-- Legend -->
+      <div class="ui-overlay ui-legend">
+        <div class="legend-title">Legend</div>
+        <div class="legend-item">
+          <div class="legend-dot" style="background:#44CC44"></div>
+          Healthy
+        </div>
+        <div class="legend-item">
+          <div class="legend-dot" style="background:#FF8C19"></div>
+          Moderate
+        </div>
+        <div class="legend-item">
+          <div class="legend-dot" style="background:#FFCC00"></div>
+          Degraded
+        </div>
+        <div class="legend-item">
+          <div class="legend-dot" style="background:#FF4444"></div>
+          Struggling
+        </div>
+        <div class="legend-item">
+          <div class="legend-dot" style="background:#666666"></div>
+          Disconnected
+        </div>
+        <div class="legend-item">
+          <div class="legend-line" style="background:#444444"></div>
+          P2P link
+        </div>
+        <div class="legend-item">
+          <div class="legend-line" style="background:#44DD44"></div>
+          Server link
+        </div>
+      </div>
+
+      <!-- Stats -->
+      <div class="ui-overlay ui-stats" id="ui-stats">
+        <div class="stats-title">Network</div>
+        <div class="stat-row">
+          <span>Nodes</span>
+          <span class="stat-value" id="stat-nodes">0</span>
+        </div>
+        <div class="stat-row">
+          <span>P2P</span>
+          <span class="stat-value" id="stat-p2p">0</span>
+        </div>
+        <div class="stat-row">
+          <span>Server</span>
+          <span class="stat-value" id="stat-server">0</span>
+        </div>
+      </div>
     </div>
   </body>
   <script type="text/javascript" src="/build.js"></script>

--- a/src/nodes/index.js
+++ b/src/nodes/index.js
@@ -23,6 +23,7 @@ function NodeIndexView () {
   this.setupCamera()
   this.setupConnectionGraph()
   this.setupClickEvents()
+  this.setupOverlay()
 
   window.addEventListener('resize', this.onresize)
   this.onresize()
@@ -139,6 +140,23 @@ NodeIndexView.prototype.setupConnectionGraph = function () {
   this.rootNode.show()
 }
 
+NodeIndexView.prototype.setupOverlay = function () {
+  this._statNodes = document.getElementById('stat-nodes')
+  this._statP2p = document.getElementById('stat-p2p')
+  this._statServer = document.getElementById('stat-server')
+  this._uiNodeCount = document.getElementById('ui-node-count')
+}
+
+NodeIndexView.prototype.updateOverlay = function (p2pCount, serverCount) {
+  var nodeCount = Object.keys(this.subviews).length
+  if (this._statNodes) this._statNodes.textContent = nodeCount
+  if (this._statP2p) this._statP2p.textContent = p2pCount
+  if (this._statServer) this._statServer.textContent = serverCount
+  if (this._uiNodeCount) {
+    this._uiNodeCount.innerHTML = '<strong>' + nodeCount + '</strong> node' + (nodeCount !== 1 ? 's' : '') + ' online'
+  }
+}
+
 NodeIndexView.prototype.setupClickEvents = function () {
   this.raycaster = new THREE.Raycaster()
   this.clickVector = new THREE.Vector3()
@@ -241,6 +259,8 @@ NodeIndexView.prototype.enterFrame = function () {
   this.serverConnections.geometry.attributes.position.needsUpdate = true
   this.webglRenderer.render(this.scene, this.camera)
   this.domRenderer.render(this.scene, this.camera)
+
+  this.updateOverlay(p2pCount, serverCount)
 
   window.requestAnimationFrame(this.enterFrame)
 }

--- a/src/nodes/single.js
+++ b/src/nodes/single.js
@@ -94,10 +94,11 @@ NodeSingleView.prototype.render = function () {
     }
 
     this.labelElement.style.color = color
+    var capacityHtml = this._renderCapacity()
     if (score != null) {
-      this.labelElement.innerHTML = '<span>' + name + '</span><span class="score" style="color:' + scoreColor + '">' + score + '</span>'
+      this.labelElement.innerHTML = '<span>' + name + '</span><span class="score" style="color:' + scoreColor + '">' + score + (capacityHtml ? ' ' + capacityHtml : '') + '</span>'
     } else {
-      this.labelElement.innerHTML = '<span>' + name + '</span>'
+      this.labelElement.innerHTML = '<span>' + name + '</span>' + (capacityHtml ? '<span class="score" style="color:' + scoreColor + '">' + capacityHtml + '</span>' : '')
     }
   } else {
     this.labelElement.textContent = 'loading'
@@ -166,6 +167,27 @@ NodeSingleView.prototype.render = function () {
       this._nudge = this._nudge.cross(new CANNON.Vec3(5, 5, 5))
     }
   }
+}
+
+NodeSingleView.prototype._renderCapacity = function () {
+  if (!this.model || this.isRoot) return ''
+  var health = this.model.data.health
+  if (!health) return ''
+
+  var down = health.downstreamCount || 0
+  var cap, full
+
+  if (this.isServer) {
+    cap = this.superview && this.superview.serverCapacity
+    full = this.superview && this.superview.serverAtCapacity
+  } else {
+    cap = this.superview && this.superview.globalK
+    full = cap != null && down >= cap
+  }
+
+  if (cap == null) return ''
+  var cls = full ? 'capacity full' : 'capacity'
+  return '<span class="' + cls + '">↓' + down + '/' + cap + '</span>'
 }
 
 NodeSingleView.prototype.generateMesh = function (radius, color) {

--- a/src/nodes/single.js
+++ b/src/nodes/single.js
@@ -95,9 +95,9 @@ NodeSingleView.prototype.render = function () {
 
     this.labelElement.style.color = color
     if (score != null) {
-      this.labelElement.innerHTML = '<span>' + name + '</span><span style="font-size:16px;color:' + scoreColor + '">' + score + '</span>'
+      this.labelElement.innerHTML = '<span>' + name + '</span><span class="score" style="color:' + scoreColor + '">' + score + '</span>'
     } else {
-      this.labelElement.textContent = name
+      this.labelElement.innerHTML = '<span>' + name + '</span>'
     }
   } else {
     this.labelElement.textContent = 'loading'

--- a/src/nodes/style.css
+++ b/src/nodes/style.css
@@ -36,6 +36,7 @@
   height: 100%;
   position: relative;
   z-index: 2;
+  pointer-events: none;
 }
 
 #node-index #webgl {

--- a/src/nodes/style.css
+++ b/src/nodes/style.css
@@ -1,12 +1,41 @@
+/* ── Main container ── */
 #node-index {
   width: 100%;
   height: 100%;
-  background-color: #1C1C1C;
+  position: relative;
+  background: radial-gradient(ellipse at 50% 40%, #1e1e2a 0%, #141418 60%, #0d0d10 100%);
+  overflow: hidden;
 }
 
+/* Subtle grid overlay */
+#node-index::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background-image:
+    linear-gradient(rgba(255, 255, 255, 0.015) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(255, 255, 255, 0.015) 1px, transparent 1px);
+  background-size: 60px 60px;
+  pointer-events: none;
+  z-index: 0;
+}
+
+/* Soft vignette */
+#node-index::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(ellipse at center, transparent 50%, rgba(0, 0, 0, 0.4) 100%);
+  pointer-events: none;
+  z-index: 4;
+}
+
+/* ── Renderer layers ── */
 #node-index #dom {
   width: 100%;
   height: 100%;
+  position: relative;
+  z-index: 2;
 }
 
 #node-index #webgl {
@@ -14,21 +43,177 @@
   height: 100%;
   position: absolute;
   top: 0;
+  left: 0;
   z-index: 1;
 }
 
+/* ── Node labels ── */
 #node-index #dom .label {
-  font-size: 22px;
-  font-family: monospace;
-  color: #FFF;
+  font-size: 18px;
+  font-family: inherit;
+  font-weight: 500;
+  color: #fff;
   background-color: transparent;
-  text-shadow: 1px 1px 2px #000;
+  text-shadow:
+    0 0 6px rgba(0, 0, 0, 0.9),
+    0 1px 3px rgba(0, 0, 0, 0.7);
   width: 160px;
   height: 50px;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
+  gap: 2px;
   overflow: visible;
   line-height: 1.2;
+  letter-spacing: 0.04em;
+  transition: opacity 0.3s ease;
+  pointer-events: none;
+  user-select: none;
+}
+
+#node-index #dom .label span {
+  display: block;
+}
+
+#node-index #dom .label .score {
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  opacity: 0.85;
+  padding: 1px 6px;
+  border-radius: 6px;
+  background: rgba(0, 0, 0, 0.35);
+}
+
+/* ── UI overlay panels ── */
+.ui-overlay {
+  position: absolute;
+  z-index: 5;
+  pointer-events: none;
+}
+
+.ui-overlay > * {
+  pointer-events: auto;
+}
+
+/* Header bar */
+.ui-header {
+  top: 0;
+  left: 0;
+  right: 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 24px;
+}
+
+.ui-header .title {
+  font-size: 15px;
+  font-weight: 600;
+  color: #e0e0e0;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.ui-header .title span {
+  color: #555;
+  font-weight: 400;
+}
+
+.ui-header .node-count {
+  font-size: 12px;
+  color: #666;
+  letter-spacing: 0.04em;
+}
+
+.ui-header .node-count strong {
+  color: #999;
+  font-weight: 600;
+}
+
+/* Legend panel */
+.ui-legend {
+  bottom: 20px;
+  left: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 14px 18px;
+  background: rgba(15, 15, 20, 0.7);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 10px;
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+}
+
+.ui-legend .legend-title {
+  font-size: 10px;
+  font-weight: 600;
+  color: #555;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  margin-bottom: 2px;
+}
+
+.ui-legend .legend-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 11px;
+  color: #888;
+  letter-spacing: 0.02em;
+}
+
+.ui-legend .legend-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.ui-legend .legend-line {
+  width: 16px;
+  height: 2px;
+  border-radius: 1px;
+  flex-shrink: 0;
+}
+
+/* Stats panel */
+.ui-stats {
+  bottom: 20px;
+  right: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 14px 18px;
+  background: rgba(15, 15, 20, 0.7);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 10px;
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+}
+
+.ui-stats .stats-title {
+  font-size: 10px;
+  font-weight: 600;
+  color: #555;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  margin-bottom: 2px;
+}
+
+.ui-stats .stat-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+  font-size: 11px;
+  color: #666;
+}
+
+.ui-stats .stat-row .stat-value {
+  color: #aaa;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
 }

--- a/src/nodes/style.css
+++ b/src/nodes/style.css
@@ -87,6 +87,17 @@
   background: rgba(0, 0, 0, 0.35);
 }
 
+#node-index #dom .label .capacity {
+  font-size: 10px;
+  font-weight: 400;
+  opacity: 0.7;
+}
+
+#node-index #dom .label .capacity.full {
+  color: #FF4444;
+  opacity: 1;
+}
+
 /* ── UI overlay panels ── */
 .ui-overlay {
   position: absolute;

--- a/src/theme/style.css
+++ b/src/theme/style.css
@@ -1,3 +1,39 @@
+/* ── Design tokens (shared with 2D visualizer) ── */
+:root {
+  /* Colors */
+  --color-bg: #1C1C1C;
+  --color-bg-panel: rgba(15, 15, 20, 0.85);
+  --color-border: rgba(255, 255, 255, 0.06);
+  --color-text: #ccc;
+  --color-text-muted: #999;
+  --color-text-dim: #888;
+  --color-text-faint: #666;
+  --color-text-heading: #555;
+  --color-text-value: #aaa;
+
+  /* Status colors */
+  --color-healthy: #44CC44;
+  --color-moderate: #FF8C19;
+  --color-degraded: #FFCC00;
+  --color-struggling: #FF4444;
+  --color-disconnected: #666666;
+  --color-server: #00CED1;
+  --color-server-node: #44DD44;
+  --color-p2p-link: #686868;
+
+  /* Typography */
+  --font-mono: 'SF Mono', 'Cascadia Code', 'Fira Code', 'JetBrains Mono', 'Consolas', monospace;
+  --font-size-xs: 10px;
+  --font-size-sm: 11px;
+  --font-size-base: 13px;
+
+  /* Panel styling */
+  --panel-radius: 10px;
+  --panel-padding: 12px 16px;
+  --panel-blur: blur(12px);
+}
+
+/* ── Reset ── */
 * {
   box-sizing: border-box;
 }
@@ -8,32 +44,98 @@ body {
   margin: 0;
   padding: 0;
   position: relative;
-  font-family: monospace;
-  color: #444;
+  font-family: var(--font-mono);
+  color: var(--color-text-faint);
 }
 
-#stats-overlay {
-  position: absolute;
+/* ── UI overlay panels ── */
+.ui-overlay {
+  position: fixed;
+  z-index: 100;
+  pointer-events: none;
+}
+
+.ui-overlay > * {
+  pointer-events: auto;
+}
+
+/* Shared panel style (glassmorphic) */
+.ui-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: var(--panel-padding);
+  background: var(--color-bg-panel);
+  border: 1px solid var(--color-border);
+  border-radius: var(--panel-radius);
+  backdrop-filter: var(--panel-blur);
+  -webkit-backdrop-filter: var(--panel-blur);
+}
+
+.ui-panel-title {
+  font-size: var(--font-size-xs);
+  font-weight: 600;
+  color: var(--color-text-heading);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  margin-bottom: 2px;
+}
+
+/* Config panel — top right */
+.ui-config {
   top: 20px;
   right: 20px;
-  background: rgba(15, 15, 20, 0.9);
-  color: #ccc;
-  padding: 12px 16px;
-  border-radius: 6px;
-  font-family: 'SF Mono', 'Cascadia Code', 'Fira Code', monospace;
-  font-size: 12px;
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  backdrop-filter: blur(10px);
-  z-index: 100;
 }
 
-#stats-overlay .stat-row {
-  display: flex;
+/* Stats panel — below config */
+.ui-stats {
+  top: 110px;
+  right: 20px;
+}
+
+/* Legend panel — bottom left */
+.ui-legend {
+  bottom: 20px;
+  left: 20px;
   gap: 8px;
-  color: #999;
 }
 
-#stats-overlay .stat-row span:last-child {
-  color: #ccc;
-  font-weight: 500;
+/* Stat rows (used in config and stats panels) */
+.stat-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+  font-size: var(--font-size-sm);
+  color: var(--color-text-faint);
+}
+
+.stat-value {
+  color: var(--color-text-value);
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+
+/* Legend items */
+.legend-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: var(--font-size-sm);
+  color: var(--color-text-dim);
+  letter-spacing: 0.02em;
+}
+
+.legend-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.legend-line {
+  width: 16px;
+  height: 2px;
+  border-radius: 1px;
+  flex-shrink: 0;
 }

--- a/src/theme/style.css
+++ b/src/theme/style.css
@@ -1,5 +1,9 @@
-* {
+*,
+*::before,
+*::after {
   box-sizing: border-box;
+  margin: 0;
+  padding: 0;
 }
 
 html,
@@ -8,6 +12,16 @@ body {
   margin: 0;
   padding: 0;
   position: relative;
-  font-family: monospace;
-  color: #444;
+  font-family: 'SF Mono', 'Cascadia Code', 'Fira Code', 'JetBrains Mono', 'Consolas', monospace;
+  color: #ccc;
+  background: #111;
+  overflow: hidden;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
+}
+
+::selection {
+  background: rgba(26, 182, 255, 0.3);
+  color: #fff;
 }

--- a/src/theme/style.css
+++ b/src/theme/style.css
@@ -11,3 +11,29 @@ body {
   font-family: monospace;
   color: #444;
 }
+
+#stats-overlay {
+  position: absolute;
+  top: 20px;
+  right: 20px;
+  background: rgba(15, 15, 20, 0.9);
+  color: #ccc;
+  padding: 12px 16px;
+  border-radius: 6px;
+  font-family: 'SF Mono', 'Cascadia Code', 'Fira Code', monospace;
+  font-size: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  backdrop-filter: blur(10px);
+  z-index: 100;
+}
+
+#stats-overlay .stat-row {
+  display: flex;
+  gap: 8px;
+  color: #999;
+}
+
+#stats-overlay .stat-row span:last-child {
+  color: #ccc;
+  font-weight: 500;
+}


### PR DESCRIPTION
## Summary

Adds UI improvements to the 3D visualizer: info panels (config, stats, legend), server capacity display, per-node capacity indicators, and improved CSS foundation.

## Changes

- Read-only info panels showing tree config, live stats, and color legend
- Server capacity display from Firebase config
- **Per-node capacity indicators** — each node label shows `↓N/K` (peers) or `↓N/cap` (server), turns red when at capacity
- Subscribes to `serverAtCapacity` flag from Firebase for server full detection
- CSS design tokens (custom properties) shared with 2D visualizer
- Glassmorphic panel styling with backdrop blur
- Improved CSS reset (`*::before`/`*::after`), font smoothing, selection styling
- Merged `origin/claude/improve-visualizer-ui-JOSKX` (pointer-events fix for trackpad zoom, foundational CSS)

## Coordinates with

This PR complements common-tater/fireflower#31, which implements the server capacity limit feature and direct server reconnection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)